### PR TITLE
Modify the check for libtool in bootstrap.sh

### DIFF
--- a/src/bootstrap.sh
+++ b/src/bootstrap.sh
@@ -29,7 +29,7 @@ fi
 # Check for needed features
 auxdir="`sed -ne 's/^[ \t]*A._CONFIG_AUX_DIR *([[ ]*\([^] )]*\).*/\1/p' $conffile`"
 pkgconfig="`grep '^[ \t]*PKG_PROG_PKG_CONFIG' $conffile >/dev/null 2>&1 && echo yes || echo no`"
-libtool="`grep '^[ \t]*A._PROG_LIBTOOL' $conffile >/dev/null 2>&1 && echo yes || echo no`"
+libtool="`grep '^[ \t]*LT_INIT' $conffile >/dev/null 2>&1 && echo yes || echo no`"
 header="`grep '^[ \t]*A._CONFIG_HEADER' $conffile >/dev/null 2>&1 && echo yes || echo no`"
 automake="`grep '^[ \t]*AM_INIT_AUTOMAKE' $conffile >/dev/null 2>&1 && echo yes || echo no`"
 aclocalflags="`sed -ne 's/^[ \t]*ACLOCAL_AMFLAGS[ \t]*=//p' Makefile.am 2>/dev/null || :`"

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -18,6 +18,11 @@ AC_CONFIG_HEADERS([config.h])
 AM_INIT_AUTOMAKE
 AM_MAINTAINER_MODE
 
+# Add support for the --enable-shared, --disable-shared, ... flags
+# This is needed for the check within bootstrap.sh, wether to run
+# libtoolize or not
+AM_PROG_LIBTOOL
+
 # Initialize libtool support
 LT_PREREQ([2.4.6])
 LT_INIT([shared])
@@ -144,7 +149,7 @@ AC_LANG_POP()
 #
 # Autoupdate added the next two lines to ensure that your configure
 # script's behavior did not change.  They are probably safe to remove.
-AC_CHECK_INCLUDES_DEFAULT
+#AC_CHECK_INCLUDES_DEFAULT
 AC_PROG_EGREP
 
 


### PR DESCRIPTION
Dear Simson, 

this PR modifies the check for libtool within `bootstrap.sh`. It is now changed to look for the `LT_INIT`-macro instead of `A._PROG_LIBTOOL`, since the latter is deprecated as stated in [0]. Now libtool is found and `ltmain.sh` will be copied. 

The error mentioned in [1] by @ajnelson-nist, that `ltmain.sh` not being found, will be resolved by this change. 
However, there is an issue with codecov, that this PR does not address, so the github action fail, whereas the compilation succeeds (at least in the github actions run in my fork). 

Best regards
Jan 

--- 
[0] https://www.gnu.org/software/libtool/manual/html_node/LT_005fINIT.html
[1] https://github.com/dfxml-working-group/dfxml_cpp/pull/1#issuecomment-873243282