### PR TITLE
Use 'latest' options for current CI runner operating systems

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ['ubuntu-20.04', 'macos-10.15']
+        os: ['ubuntu-latest', 'macos-latest']
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
This PR matches with the DFXML Python repository's [PR 42](https://github.com/dfxml-working-group/dfxml_python/pull/42).